### PR TITLE
Make vecst nrn90 compat

### DIFF
--- a/README.html
+++ b/README.html
@@ -62,5 +62,9 @@ phi(phi0) alters celsius appropriately.
 Bill Lytton developed the fig 3a simulation and model
 descriptions. Michael Hines created the fig1a gui.
 
+Changelog
+---------
 20140821 ModelDB admininstrator: updates to run on mswin
+20220520 Updated MOD files to contain valid C++ and be compatible
+         with the upcoming versions 8.2 and 9.0 of NEURON.
 </pre></html>

--- a/vecst.mod
+++ b/vecst.mod
@@ -54,7 +54,6 @@ ASSIGNED { RES }
 VERBATIM
 #include <stdlib.h>
 #include <math.h>
-/* #include <values.h> /* contains MAXLONG */
 #include <limits.h>
 #include <time.h> 
 
@@ -66,6 +65,7 @@ VERBATIM
 #endif
 
 #ifndef NRN_VERSION_GTEQ_8_2_0
+extern double hoc_epsilon;
 extern FILE* hoc_obj_file_arg(int narg);
 extern void vector_resize();
 extern int vector_instance_px();
@@ -491,7 +491,7 @@ static double keyind(void* vv) {
   int i, j, k, ni, nk, nv[10], num;
   double *ind, *key, *vvo[10];
   ni = vector_instance_px(vv, &ind); // vv is ind
-  for (i=0;ifarg(i);i++); i--; // drop back by one to get numarg()
+  for (i=0;ifarg(i);i++) {} i--; // drop back by one to get numarg()
   if (i>10) hoc_execerror("ERR: keyind can only handle 9 vectors", 0);
   num = i-1; /* number of vectors to be picked apart */
   for (i=0;i<num;i++) { 
@@ -937,7 +937,6 @@ static double smgs(void* vv) {
   int i, j, nx, xv, nsum, points, maxsz;
   double *x, *sum;
   double  low , high , step , var , svar , scale , arg;
-  extern double hoc_epsilon;
   
   nsum = vector_instance_px(vv, &sum);
   nx = vector_arg_px(1,&x);

--- a/vecst.mod
+++ b/vecst.mod
@@ -64,16 +64,23 @@ VERBATIM
 #include <limits.h>
 #define MAXLONG LONG_MAX
 #endif
+
+#ifndef NRN_VERSION_GTEQ_8_2_0
+extern FILE* hoc_obj_file_arg(int narg);
+extern void vector_resize();
+extern int vector_instance_px();
+#endif
+
 /* some machines do not have drand48 and srand48 so use the implementation
 at the end of this file */
-extern double my_drand48();
-extern void my_srand48();
+
+double my_drand48();
+void my_srand48(long seedval);
 #undef drand48
 #undef srand48
 #define drand48 my_drand48
 #define srand48 my_srand48
 
-extern double drand48();
 // end of excerpt
 
 ENDVERBATIM
@@ -319,7 +326,7 @@ static double fewind(void* vv) {
         for (j=0;j<num;j++) {
           for (i=0;i<ni;i++) x[i]=vvo[j][scr[i]];    
           for (i=0;i<ni;i++) vvo[j][i]=x[i];   
-          vv=vector_arg(j+2); vector_resize(vv, ni);
+          vv=vector_arg(j+2); vector_resize((IvocVect*)vv, ni);
         }
 	return ni;
 }
@@ -331,7 +338,7 @@ VERBATIM
 static double iwr(void* vv) {
   int i, j, nx;
   double *x;
-  FILE* f, *hoc_obj_file_arg();
+  FILE* f;
   f = hoc_obj_file_arg(1);
   nx = vector_instance_px(vv, &x);
   if (nx>scrsz) { 
@@ -352,7 +359,7 @@ VERBATIM
 static double ird(void* vv) {
   int i, j, nx, n;
   double *x;
-  FILE* f, *hoc_obj_file_arg();
+  FILE* f;
   f = hoc_obj_file_arg(1);
   nx = vector_instance_px(vv, &x);
   fread(&n,sizeof(int),1,f);  // size
@@ -362,9 +369,9 @@ static double ird(void* vv) {
     scr=(int *)ecalloc(scrsz, sizeof(int));
   }
   if (n!=nx) { 
-    nx=vector_buffer_size(vv);
+    nx=vector_buffer_size((IvocVect*)vv);
     if (n<=nx) {
-      vector_resize(vv, n); nx=n; 
+      vector_resize((IvocVect*)vv, n); nx=n;
     } else {
       printf("%d > %d :: ",n,nx);
       hoc_execerror("Vector max capacity too small for ird ", 0);
@@ -389,7 +396,7 @@ static double insct(void* vv) {
         if (k==nx) { 
           printf("\tinsct WARNING: ran out of room: %d\n",k);
           for (;i<nv1;i++,j=0) for (;j<nv2;j++) if (v1[i]==v2[j]) k++;
-        } else { vector_resize(vv, k); } /* can't resize to make bigger */
+        } else { vector_resize((IvocVect*)vv, k); } /* can't resize to make bigger */
 	return (double)k;
 }
 ENDVERBATIM
@@ -411,6 +418,7 @@ static double cvlv(void* vv) {
       if (k>0 && k<nsrc-1) x[i]+=filt[j]*src[k];
     }
   }
+  return 0.;
 }
 ENDVERBATIM
 
@@ -430,6 +438,7 @@ static double intrp(void* vv) {
     for (i=la+1; i<lb; i++) x[i]= a + (b-a)/(lb-la)*(i-la);
     a=b; la=lb;
   }
+  return 0.;
 }
 ENDVERBATIM
 
@@ -469,7 +478,7 @@ static double nind(void* vv) {
           }
           for (k=last+1;k<nx;k++,m++) { x[m]=vvo[j][k]; }
           for (i=0;i<c;i++) vvo[j][i]=x[i];   
-          vv=vector_arg(j+2); vector_resize(vv, c);
+          vv=vector_arg(j+2); vector_resize((IvocVect*)vv, c);
         }
 	return c;
 }
@@ -504,7 +513,7 @@ static double keyind(void* vv) {
     }
     if (i==nk) ind[k++]=j; // all equal
   }
-  vector_resize(vv, k);
+  vector_resize((IvocVect*)vv, k);
   return k;
 }
 ENDVERBATIM
@@ -567,7 +576,7 @@ VERBATIM
 static double vpr(void* vv) {
   int i, nx;
   double* x;
-  FILE* f, *hoc_obj_file_arg();
+  FILE* f;
   nx = vector_instance_px(vv, &x);
   if (ifarg(1)) { 
     f = hoc_obj_file_arg(1);
@@ -660,6 +669,7 @@ static double bpeval(void* vv) {
   } else {
     for (i=0;i<n;i++) vo[i]=outp[i]*(1.-1.*outp[i])*del[i];
   }
+  return 0.;
 }
 ENDVERBATIM
  
@@ -744,7 +754,7 @@ static double xing(void* vv) {
       if (f==1) { f=0; } /* just passed going down */
     }
   }
-  vector_resize(vv, j);
+  vector_resize((IvocVect*)vv, j);
   return (double)i;
 }
 ENDVERBATIM
@@ -877,13 +887,6 @@ VERBATIM {
 ENDVERBATIM
 }
  
-:* PROCEDURE sleep() 
-PROCEDURE sleep() {
-VERBATIM
-  sleep(1);
-ENDVERBATIM
-}
-
 :* logfac (n)
 : from numerical recipes p.214
 FUNCTION logfac (n) {
@@ -911,7 +914,7 @@ VERBATIM {
         j=ntop++;
         a[ntop]=a[j]*ntop;
       }
-    return log(a[n]);
+      return log(a[n]);
     }
 }
 ENDVERBATIM
@@ -945,9 +948,9 @@ static double smgs(void* vv) {
 
   points = (int)((high-low)/step+hoc_epsilon);
   if (nsum!=points) { 
-    maxsz=vector_buffer_size(vv);
+    maxsz=vector_buffer_size((IvocVect*)vv);
     if (points<=maxsz) {
-      vector_resize(vv, nsum); nsum=points; 
+      vector_resize((IvocVect*)vv, nsum); nsum=points;
     } else {
       printf("%d > %d :: ",points,maxsz);
       hoc_execerror("Vector max capacity too small for ird ", 0);
@@ -1089,9 +1092,7 @@ next()
 	x[0] = LOW(p[0]);
 }
 
-void
-my_srand48(seedval)
-long seedval;
+void my_srand48(long seedval)
 {
 	SEED(X0, LOW(seedval), HIGH(seedval));
 }


### PR DESCRIPTION
Making vecst mod compat with cpp compilers (nrn90).

**Note**: There's a problematic `sleep` function  which doesnt seem to be used anywhere. Can it be removed?